### PR TITLE
Revert "Remove src directory from installed files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Eleventy plugin for generating ActivityPub actor files",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "files": ["./lib/**/*"],
+  "files": ["./src/**/*", "./lib/**/*"],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",


### PR DESCRIPTION
This reverts commit 1c4239b6e21982c67a6e6d22c6409682f5ecaef6.

We need the src/ directory to generate the outbox files