### PR TITLE
Rename outbox_1 to outbox to get it working

### DIFF
--- a/src/activityPubPlugin.ts
+++ b/src/activityPubPlugin.ts
@@ -60,7 +60,7 @@ export const activityPubPlugin = (
 			}
 
 			if (outbox) {
-				actorDef.outbox = `${url}/outbox_1`;
+				actorDef.outbox = `${url}/outbox`;
 			}
 
 			fs.writeFileSync(`${dir.output}/${username}`, JSON.stringify(actorDef));
@@ -138,7 +138,7 @@ export const activityPubPlugin = (
 	eleventyConfig.addFilter("activitypuboutbox", (items: CollectionItem[]) => ({
 		"@context": "https://www.w3.org/ns/activitystreams",
 		type: "OrderedCollectionPage",
-		id: `https://${domain}/outbox_1`,
+		id: `https://${domain}/outbox`,
 		orderedItems: items.sort().map((item) => ({
 			actor: `https://${domain}/${username}`,
 			type: "Create",


### PR DESCRIPTION
I'm not sure what `outbox_1` was for, but when I created my site with the plugin, there were no posts available because `/outbox_1` was a 404. I renamed it to `outbox` which I believe is where the actual content is and it seems to be working better.